### PR TITLE
Remove unnecessary dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,6 @@ dbus-crossroads = "^0.2.1"
 objc = "0.2.7"
 objc-foundation = "0.1.1"
 objc_id = "0.1.1"
-[target."cfg(any(target_os = \"windows\", target_os = \"freebsd\"))".dependencies]
-libusb = "0.3.0"
 
 [dev-dependencies]
 pretty_env_logger = "0.2"

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -8,11 +8,6 @@ mod bluez;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub use self::bluez::Peripheral;
 
-#[cfg(any(target_os = "windows", target_os = "freebsd"))]
-mod usb;
-#[cfg(any(target_os = "windows", target_os = "freebsd"))]
-pub use self::usb::Peripheral;
-
 // TODO: Add struct / traits to implement for each OS
 //
 // pub enum BindingsEvent {

--- a/src/peripheral/usb/mod.rs
+++ b/src/peripheral/usb/mod.rs
@@ -1,1 +1,0 @@
-use libusb;


### PR DESCRIPTION
The unmaintained dependency `libusb` is never actually used, and the Windows/FreeBSD builds don't do anything.

The existance of `libusb` was causing problems with `cargo fmt --all ----check`, due to an old version of `bitset`.

A suitable replacement for the future may be `rusb`: https://github.com/a1ien/rusb

This is intended to be submitted upstream