### PR TITLE
Require pairing for GATT notifications/indications

### DIFF
--- a/src/gatt/characteristic.rs
+++ b/src/gatt/characteristic.rs
@@ -1,4 +1,4 @@
-use super::{descriptor::Descriptor, event::EventSender};
+use super::descriptor::Descriptor;
 use std::{
     collections::HashSet,
     hash::{Hash, Hasher},
@@ -31,4 +31,4 @@ impl Characteristic {
 
 impl_uuid_hash_eq!(Characteristic);
 
-properties!(WriteWithAndWithoutResponse, EventSender, { notify: EventSender, indicate: EventSender });
+properties!(WriteWithAndWithoutResponse, {notify, indicate});

--- a/src/gatt/descriptor.rs
+++ b/src/gatt/descriptor.rs
@@ -1,4 +1,3 @@
-use super::event::EventSender;
 use std::hash::{Hash, Hasher};
 use uuid::Uuid;
 
@@ -21,4 +20,4 @@ impl Descriptor {
 
 impl_uuid_hash_eq!(Descriptor);
 
-properties!(WriteWithResponse, EventSender);
+properties!(WriteWithResponse);

--- a/src/gatt/gatt_properties.rs
+++ b/src/gatt/gatt_properties.rs
@@ -38,14 +38,14 @@ macro_rules! _properties {
         pub struct Properties {
             pub(crate) read: Option<Read>,
             pub(crate) write: Option<Write>,
-            $(pub(crate) $member: Option<crate::gatt::event::EventSender>,)*
+            $(pub(crate) $member: Option<ServerInitiated>,)*
         }
 
         impl Properties {
             pub fn new(
                 read: Option<Read>,
                 write: Option<Write>,
-                $($member: Option<crate::gatt::event::EventSender>,)*
+                $($member: Option<ServerInitiated>,)*
             ) -> Self {
                 Properties {
                     read,
@@ -60,6 +60,7 @@ macro_rules! _properties {
         }
 
         _define_operation_struct!(Read);
+        _define_operation_struct!(ServerInitiated);
 
         #[derive(Debug, Clone)]
         pub enum Secure {

--- a/src/gatt/gatt_properties.rs
+++ b/src/gatt/gatt_properties.rs
@@ -1,13 +1,25 @@
+macro_rules! _define_operation_struct {
+    ($struct:ident) => {
+        #[derive(Debug, Clone)]
+        pub struct $struct(pub Secure);
+
+        impl $struct {
+            pub fn sender(self: Self) -> crate::gatt::event::EventSender {
+                self.0.sender()
+            }
+        }
+    };
+}
 macro_rules! _write_type {
-    (WriteWithAndWithoutResponse, $event_sender:ident, $secure:ident) => {
+    (WriteWithAndWithoutResponse) => {
         #[derive(Debug, Clone)]
         pub enum Write {
-            WithResponse($secure),
-            WithoutResponse($event_sender),
+            WithResponse(Secure),
+            WithoutResponse(crate::gatt::event::EventSender),
         }
 
         impl Write {
-            pub fn sender(self: Self) -> $event_sender {
+            pub fn sender(self: Self) -> crate::gatt::event::EventSender {
                 match self {
                     Write::WithResponse(event_sender) => event_sender.sender(),
                     Write::WithoutResponse(event_sender) => event_sender,
@@ -15,40 +27,25 @@ macro_rules! _write_type {
             }
         }
     };
-    (WriteWithResponse, $event_sender:ident, $secure:ident) => {
-        #[derive(Debug, Clone)]
-        pub struct Write(pub $secure);
-
-        impl Write {
-            pub fn sender(self: Self) -> $event_sender {
-                self.0.sender()
-            }
-        }
-
-        impl std::ops::Deref for Write {
-            type Target = $secure;
-
-            fn deref(&self) -> &Self::Target {
-                &self.0
-            }
-        }
+    (WriteWithResponse) => {
+        _define_operation_struct!(Write);
     };
 }
 
 macro_rules! _properties {
-    ($event_sender:ident, { $($member:ident: $member_type:ty,)* }) => {
+    ({ $($member:ident,)* }) => {
         #[derive(Debug, Clone)]
         pub struct Properties {
             pub(crate) read: Option<Read>,
             pub(crate) write: Option<Write>,
-            $(pub(crate) $member: Option<$member_type>,)*
+            $(pub(crate) $member: Option<crate::gatt::event::EventSender>,)*
         }
 
         impl Properties {
             pub fn new(
                 read: Option<Read>,
                 write: Option<Write>,
-                $($member: Option<$member_type>,)*
+                $($member: Option<crate::gatt::event::EventSender>,)*
             ) -> Self {
                 Properties {
                     read,
@@ -62,31 +59,16 @@ macro_rules! _properties {
             }
         }
 
-        #[derive(Debug, Clone)]
-        pub struct Read(pub Secure);
-
-        impl Read {
-            pub fn sender(self: Self) -> $event_sender {
-                self.0.sender()
-            }
-        }
-
-        impl std::ops::Deref for Read {
-            type Target = Secure;
-
-            fn deref(&self) -> &Secure {
-                &self.0
-            }
-        }
+        _define_operation_struct!(Read);
 
         #[derive(Debug, Clone)]
         pub enum Secure {
-            Secure($event_sender),
-            Insecure($event_sender),
+            Secure(crate::gatt::event::EventSender),
+            Insecure(crate::gatt::event::EventSender),
         }
 
         impl Secure {
-            pub fn sender(self: Self) -> $event_sender {
+            pub fn sender(self: Self) -> crate::gatt::event::EventSender {
                 match self {
                     Secure::Secure(event_sender) => event_sender,
                     Secure::Insecure(event_sender) => event_sender,
@@ -95,30 +77,21 @@ macro_rules! _properties {
         }
     }
 }
-
 macro_rules! properties {
-    (WriteWithResponse, $event_sender:ident, { $($member:ident: $member_type:ty,)* }) => {
-        _write_type!(WriteWithResponse, $event_sender, Secure);
-        _properties!($event_sender, { $($member: $member_type,)* });
+    (WriteWithResponse, { $($member:ident),* }) => {
+        _write_type!(WriteWithResponse);
+        _properties!({ $($member,)* });
     };
-    (WriteWithResponse, $event_sender:ident, { $($member:ident: $member_type:ty),* }) => {
-        _write_type!(WriteWithResponse, $event_sender, Secure);
-        _properties!($event_sender, { $($member: $member_type,)* });
+    (WriteWithResponse) => {
+        _write_type!(WriteWithResponse);
+        _properties!({});
     };
-    (WriteWithResponse, $event_sender:ident) => {
-        _write_type!(WriteWithResponse, $event_sender, Secure);
-        _properties!($event_sender, {});
+    (WriteWithAndWithoutResponse, { $($member:ident),* }) => {
+        _write_type!(WriteWithAndWithoutResponse);
+        _properties!({ $($member,)* });
     };
-    (WriteWithAndWithoutResponse, $event_sender:ident, { $($member:ident: $member_type:ty,)* }) => {
-        _write_type!(WriteWithAndWithoutResponse, $event_sender, Secure);
-        _properties!($event_sender, { $($member: $member_type,)* });
-    };
-    (WriteWithAndWithoutResponse, $event_sender:ident, { $($member:ident: $member_type:ty),* }) => {
-        _write_type!(WriteWithAndWithoutResponse, $event_sender, Secure);
-        _properties!($event_sender, { $($member: $member_type,)* });
-    };
-    (WriteWithAndWithoutResponse, $event_sender:ident) => {
-        _write_type!(WriteWithAndWithoutResponse, $event_sender:ident, Secure);
-        properties!($event_sender, {});
+    (WriteWithAndWithoutResponse) => {
+        _write_type!(WriteWithAndWithoutResponse);
+        properties!({});
     };
 }

--- a/src/peripheral/bluez/gatt/characteristic.rs
+++ b/src/peripheral/bluez/gatt/characteristic.rs
@@ -169,7 +169,8 @@ impl Characteristic {
                         .notify
                         .clone()
                         .or_else(|| characteristic.properties.indicate.clone())
-                        .ok_or_else(|| MethodErr::from((BLUEZ_ERROR_NOTSUPPORTED, "")))?;
+                        .ok_or_else(|| MethodErr::from((BLUEZ_ERROR_NOTSUPPORTED, "")))?
+                        .sender();
                     event_sender
                         .send(gatt::event::Event::NotifySubscribe(notify_subscribe))
                         .await
@@ -189,7 +190,8 @@ impl Characteristic {
                         .notify
                         .clone()
                         .or_else(|| characteristic.properties.indicate.clone())
-                        .ok_or_else(|| MethodErr::from((BLUEZ_ERROR_NOTSUPPORTED, "")))?;
+                        .ok_or_else(|| MethodErr::from((BLUEZ_ERROR_NOTSUPPORTED, "")))?
+                        .sender();
                     event_sender
                         .send(gatt::event::Event::NotifyUnsubscribe)
                         .await

--- a/src/peripheral/bluez/gatt/flags.rs
+++ b/src/peripheral/bluez/gatt/flags.rs
@@ -10,6 +10,7 @@ pub trait Flags {
 impl Flags for CharacteristicProperties {
     fn flags(self: &Self) -> Vec<String> {
         let mut flags = vec![];
+
         if let Some(ref read) = self.read {
             let read_flags: &[&str] = match read.0 {
                 characteristic::Secure::Secure(_) => &["secure-read", "encrypt-authenticated-read"],
@@ -31,12 +32,24 @@ impl Flags for CharacteristicProperties {
             flags.extend_from_slice(write_flag);
         }
 
-        if self.notify.is_some() {
-            flags.push("notify");
+        if let Some(ref notify) = self.notify {
+            let notify_flags: &[&str] = match notify.0 {
+                characteristic::Secure::Secure(_) => {
+                    &["encrypt-authenticated-notify", "secure-notify"]
+                }
+                characteristic::Secure::Insecure(_) => &["notify"],
+            };
+            flags.extend_from_slice(notify_flags);
         }
 
-        if self.indicate.is_some() {
-            flags.push("indicate");
+        if let Some(ref indicate) = self.indicate {
+            let indicate_flags: &[&str] = match indicate.0 {
+                characteristic::Secure::Secure(_) => {
+                    &["encrypt-authenticated-indicate", "secure-indicate"]
+                }
+                characteristic::Secure::Insecure(_) => &["indicate"],
+            };
+            flags.extend_from_slice(indicate_flags);
         }
 
         flags.iter().map(|s| String::from(*s)).collect()

--- a/tests/peripheral.rs
+++ b/tests/peripheral.rs
@@ -40,7 +40,9 @@ async fn it_advertises_gatt() {
             Some(characteristic::Write::WithResponse(
                 characteristic::Secure::Insecure(sender_characteristic.clone()),
             )),
-            Some(sender_characteristic),
+            Some(characteristic::ServerInitiated(
+                characteristic::Secure::Insecure(sender_characteristic),
+            )),
             None,
         ),
         None,


### PR DESCRIPTION
Add support for the `x-indicate` and `x-notify` flags in BlueZ 5.62. This requires a breaking API change